### PR TITLE
修复js引擎参数错误问题

### DIFF
--- a/MediaSpider/src/main/java/com/tainzhi/mediaspider/utils/JsEngine.kt
+++ b/MediaSpider/src/main/java/com/tainzhi/mediaspider/utils/JsEngine.kt
@@ -26,7 +26,7 @@ object JsEngine {
             rhino.evaluateString(scope, js, "script", 1, null)
             val f = scope.get(functionName, scope)
             if (f is Function) {
-                val result = f.call(rhino, scope, scope, arrayOf(params))
+                val result = f.call(rhino, scope, scope, params)
                 return Context.toString(result)
             } else {
                 throw Exception("$functionName} is not js function")


### PR DESCRIPTION
现有逻辑会将多个参数作为一个二维数组传入javascript 方法, 移除arrayOf() 即可修复